### PR TITLE
Add flag for other wikis (#2)

### DIFF
--- a/grok.py
+++ b/grok.py
@@ -9,15 +9,15 @@ import webbrowser
 
 
 def get_data(request_string):
-    request_data = requests.get(request_string).json()
-    if "parse" not in request_data.keys():
-        print("No results found")
-        exit(0)
-    request_data = request_data['parse']
-    # Regexes to pull out most of the html and multiple newlines
-    request_data['text']['*'] = re.sub("<[^>]*>", "", str(request_data['text']['*']))
-    request_data['text']['*'] = re.sub('\n+', '\n', request_data['text']['*'])
-    return request_data
+	request_data = requests.get(request_string).json()
+	if "parse" not in request_data.keys():
+		print("No results found")
+		exit(0)
+	request_data = request_data['parse']
+	# Regexes to pull out most of the html and multiple newlines
+	request_data['text']['*'] = re.sub("<[^>]*>", "", str(request_data['text']['*']))
+	request_data['text']['*'] = re.sub('\n+', '\n', request_data['text']['*'])
+	return request_data
 
 
 start_time = time.time()
@@ -28,94 +28,92 @@ wiki = 'https://en.wikipedia.org/w/api.php?'
 search_string = ""
 
 if len(sys.argv) == 1:
-    print("Enter a topic to search about, Grok will print the wikipedia summary")
-    print("-Verbose flag prints whole article")
-    print("-Concise flag prints a short summary")
-    print("-Search flag searches wikipedia")
-    print("-Browser flag opens page in web browser")
-    print("-Debug flag prints debug info")
-    print("-----USE CASES-----")
-    print("$grok <search_string> [flags]")
-    print("$grok [flags] <search_string>")
-    print("$grok <search_string> [flags] <--other> <wiki_url>")
-    print("/nNOTE: search string and flags order does not matter.")
-    print("NOTE: when using -o, last argument MUST be the wiki's url.")
-    exit(0)
+	print("Enter a topic to search about, Grok will print the wikipedia summary")
+	print("-Verbose flag prints whole article")
+	print("-Concise flag prints a short summary")
+	print("-Search flag searches wikipedia")
+	print("-Browser flag opens page in web browser")
+	print("-Debug flag prints debug info")
+	print("-----USE CASES-----")
+	print("$grok <search_string> [flags]")
+	print("$grok [flags] <search_string>")
+	print("$grok <search_string> [flags] <--other> <wiki_url>")
+	print("NOTE: search string and flags order does not matter.")
+	print("NOTE: when using -o, last argument MUST be the wiki's url.")
+	exit(0)
 
 for arg in sys.argv[1:]:
 	if arg[0] == '-':
-	    arg = arg.lower()
-	    # Flags
-	    """
-	look for flag only if arg is not a search string
-	resolving issues with search subject containing '-'
-	ex: 'arc-en-ciel'
-	last version using 'any' to find flags would have
-	seen the -c flag in 'arc-en-ciel'
-	    """
-	    verbose = arg in ["-v","--verbose"]
-	    concise = arg in ["-c","--concise"]
-	    search = arg in ["-s","--search"]
-	    browser = arg in ["-b","--browser"]
-	    debug = arg in ["-d","--debug"]
-	    other = arg in ["-o","--other"]
+		arg = arg.lower()
+		# Flags
+		"""
+		look for flag only if arg is not a search string
+		resolving issues with search subject containing '-'
+		ex: 'arc-en-ciel'
+		last version using 'any' to find flags would have
+		seen the -c flag in 'arc-en-ciel'
+		"""
+		verbose = arg in ["-v","--verbose"]
+		concise = arg in ["-c","--concise"]
+		search = arg in ["-s","--search"]
+		browser = arg in ["-b","--browser"]
+		debug = arg in ["-d","--debug"]
+		other = arg in ["-o","--other"]
 
 # TODO: get proper sections
 length = 250
 if verbose:
-    length = 100000000
+	length = 100000000
 if concise:
-    length = 100
+	length = 100
 
 
 # Combine anything that isn't a flag into a search string
 # And use last arg as wiki url IF --other is used (last arg won't be in search_string)
 if other:
-    wiki = sys.argv[-1] #new wiki url
-    for arg in sys.argv[1:-1]:
-	if arg[0] != '-':
-	search_string += arg + "_"
+	wiki = sys.argv[-1] #new wiki url
+	for arg in sys.argv[1:-1]:
+		if arg[0] != '-':
+			search_string += arg + "_"
 else:
-    for arg in sys.argv[1:]:
-	if arg[0] != '-':
-	search_string += arg + "_"
-
-	
+	for arg in sys.argv[1:]:
+		if arg[0] != '-':
+			search_string += arg + "_"
 
 if browser:
-    webbrowser.open(wiki + 'wiki/' + search_string)
-    exit(0)
+	webbrowser.open(wiki + 'wiki/' + search_string)
+	exit(0)
 
 if search:
-    # Using opensearch because it seems to be more broadly supported
-    search_request = wiki + 'action=opensearch&search=' + search_string + '&limit=10&namespace=0'
-    data = json.loads(requests.get(search_request).text)
-    titles = data[1]
-    if len(titles) == 0:
-        print("No results found")
-        exit(0)
+	# Using opensearch because it seems to be more broadly supported
+	search_request = wiki + 'action=opensearch&search=' + search_string + '&limit=10&namespace=0'
+	data = json.loads(requests.get(search_request).text)
+	titles = data[1]
+	if len(titles) == 0:
+		print("No results found")
+		exit(0)
 
-    for i in range(0, len(titles)):
-        print(str(i) + ". " + titles[i] + ": ", end='')
-        # Some wikis provide snippet summaries with the search and it is much faster than grabbing the page
-        if len(data) > 2:
-            print(data[2][i])
-        else:
-            summary = get_data(wiki + '&action=parse&page=' + titles[i] + '&redirects=&format=json')['text']['*']
-            print(re.sub('\n', "", summary[:length]))
+	for i in range(0, len(titles)):
+		print(str(i) + ". " + titles[i] + ": ", end='')
+		# Some wikis provide snippet summaries with the search and it is much faster than grabbing the page
+		if len(data) > 2:
+			print(data[2][i])
+		else:
+			summary = get_data(wiki + '&action=parse&page=' + titles[i] + '&redirects=&format=json')['text']['*']
+			print(re.sub('\n', "", summary[:length]))
 
-    if debug:
-        print(search_request)
-        print("Completed in %s seconds" % (time.time() - start_time))
+if debug:
+	print(search_request)
+	print("Completed in %s seconds" % (time.time() - start_time))
 
 
-    index = input('Select the page by pressing a number and then enter: ')
-    start_time = time.time()
-    if index.isdigit() and 0 <= int(index) < len(titles):
-        # This can lead to redundant requests if program had to grab all the search pages
-        search_string = titles[int(index)]
-    else:
-        exit(0)
+index = input('Select the page by pressing a number and then enter: ')
+start_time = time.time()
+if index.isdigit() and 0 <= int(index) < len(titles):
+	# This can lead to redundant requests if program had to grab all the search pages
+	search_string = titles[int(index)]
+else:
+	exit(0)
 
 args = '&action=parse&page=' + search_string + '&redirects=&format=json'
 data = get_data(wiki + args)
@@ -123,5 +121,5 @@ print(data['title'] + ': ' + data['text']['*'][:length])
 
 
 if debug:
-    print(wiki + args)
-    print("Completed in %s seconds" % (time.time() - start_time))
+	print(wiki + args)
+	print("Completed in %s seconds" % (time.time() - start_time))

--- a/grok.py
+++ b/grok.py
@@ -22,25 +22,10 @@ def get_data(request_string):
 
 start_time = time.time()
 
-# Flags
-verbose = any("-v" in arg.lower() for arg in sys.argv)
-concise = any("-c" in arg.lower() for arg in sys.argv)
-search = any("-s" in arg.lower() for arg in sys.argv)
-browser = any("-b" in arg.lower() for arg in sys.argv)
-debug = any("-d" in arg.lower() for arg in sys.argv)
-
-# TODO: get proper sections
-length = 250
-if verbose:
-    length = 100000000
-if concise:
-    length = 100
-
 # Searching different wikis
 # This is really hit or miss based on different mediawiki versions
 wiki = 'https://en.wikipedia.org/w/api.php?'
 search_string = ""
-
 
 if len(sys.argv) == 1:
     print("Enter a topic to search about, Grok will print the wikipedia summary")
@@ -49,13 +34,53 @@ if len(sys.argv) == 1:
     print("-Search flag searches wikipedia")
     print("-Browser flag opens page in web browser")
     print("-Debug flag prints debug info")
+    print("-----USE CASES-----")
+    print("$grok <search_string> [flags]")
+    print("$grok [flags] <search_string>")
+    print("$grok <search_string> [flags] <--other> <wiki_url>")
+    print("/nNOTE: search string and flags order does not matter.")
+    print("NOTE: when using -o, last argument MUST be the wiki's url.")
     exit(0)
 
-# Combine anything that isn't a flag into a search string
 for arg in sys.argv[1:]:
-    if arg[0] != '-':
-        search_string += arg + "_"
+	if arg[0] == '-':
+	    arg = arg.lower()
+	    # Flags
+	    """
+	look for flag only if arg is not a search string
+	resolving issues with search subject containing '-'
+	ex: 'arc-en-ciel'
+	last version using 'any' to find flags would have
+	seen the -c flag in 'arc-en-ciel'
+	    """
+	    verbose = arg in ["-v","--verbose"]
+	    concise = arg in ["-c","--concise"]
+	    search = arg in ["-s","--search"]
+	    browser = arg in ["-b","--browser"]
+	    debug = arg in ["-d","--debug"]
+	    other = arg in ["-o","--other"]
 
+# TODO: get proper sections
+length = 250
+if verbose:
+    length = 100000000
+if concise:
+    length = 100
+
+
+# Combine anything that isn't a flag into a search string
+# And use last arg as wiki url IF --other is used (last arg won't be in search_string)
+if other:
+    wiki = sys.argv[-1] #new wiki url
+    for arg in sys.argv[1:-1]:
+	if arg[0] != '-':
+	search_string += arg + "_"
+else:
+    for arg in sys.argv[1:]:
+	if arg[0] != '-':
+	search_string += arg + "_"
+
+	
 
 if browser:
     webbrowser.open(wiki + 'wiki/' + search_string)


### PR DESCRIPTION
-Added -o --other flag:
Allows the user to use a wiki's url as last argument to search
said wiki without having to modify grok.py in text editor.
When the -o flag is in use, the last argument is the new wiki's url
and is ignored in the search string's detection.

-Modified flag's detection
Changed previous flag detection using 'any' and added a for loop
to ensure the flag's argument starts with '-'. This prevents flag's
detection in search string like 'arc-en-ciel'. I've also added full
flags to detection (--verbose, --search, etc...).

-Added use cases
Added use cases to the help section to ensure the user's understanding
of how to use grok's flags and search string. Tried to explain the -o
flag the best i could since it forces the last argument to be an url.

Ps: This is my first time using git, any contructive criticism is
welcome.

Signed-off-by: Étienne Demers edemers@dept-info.crosemont.quebec
